### PR TITLE
[Bugfix, #6] now uses the table_name if there is one

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ gemspec
 
 group :test do
   gem 'rake'
-  gem "codeclimate-test-reporter"
+  gem 'codeclimate-test-reporter'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    acts_as_read_only_i18n_localised (0.0.2)
+    acts_as_read_only_i18n_localised (0.0.3)
       i18n
 
 GEM
@@ -64,4 +64,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.11.2
+   1.12.3

--- a/lib/acts_as_read_only_i18n_localised/version.rb
+++ b/lib/acts_as_read_only_i18n_localised/version.rb
@@ -1,3 +1,3 @@
 module ActsAsReadOnlyI18nLocalised
-  VERSION = '0.0.2'.freeze
+  VERSION = '0.0.3'.freeze
 end

--- a/spec/acts_as_read_only_i18n_localised_spec.rb
+++ b/spec/acts_as_read_only_i18n_localised_spec.rb
@@ -14,7 +14,7 @@ end
 
 class HierarchicalTestModel < TestModel
   attr_accessor :children, :parent
-  
+
   def initialize(options)
     super(options)
     unless options[:parent].nil?
@@ -28,17 +28,16 @@ end
 
 class CustomSlugModel
   include ActsAsReadOnlyI18nLocalised
-  
+
   acts_as_read_only_i18n_localised :name
   use_custom_slug :slug_maker
 
   def slug_maker
-    "slug_it_up"
+    'slug_it_up'
   end
 end
 
 describe 'ActsAsReadOnlyI18nLocalised' do
-  
   before :all do
     I18n.enforce_available_locales = false
     I18n.locale = :en
@@ -79,7 +78,7 @@ describe 'ActsAsReadOnlyI18nLocalised' do
     end
 
     context 'child' do
-      let(:child)    { HierarchicalTestModel.new(slug: 'child', parent: parent) }
+      let(:child) { HierarchicalTestModel.new(slug: 'child', parent: parent) }
       let(:key)      { :'hierarchical_test_model.parent.children.child.name' }
       let(:expected) { 'test-child-result' }
 
@@ -94,12 +93,41 @@ describe 'ActsAsReadOnlyI18nLocalised' do
   end
 
   context 'with custom slug maker' do
-    let!(:model)    { CustomSlugModel.new }
+    let!(:model)   { CustomSlugModel.new }
     let(:key)      { :"custom_slug_model.slug_it_up.name" }
     let(:expected) { 'test-custom-result' }
 
     it 'responds to name' do
       expect(model).to respond_to :name
+    end
+
+    it 'the name has the expected value' do
+      expect(model.name).to eq expected
+    end
+  end
+
+  context 'with access to String.pluralize', verify_stubs: false do
+    let(:model)    { TestModel.new(slug: 'test') }
+    let(:key)      { :"test_models.test.name" }
+    let(:expected) { 'test-custom-result' }
+
+    before :each do
+      allow_any_instance_of(String).to receive(:pluralize)
+        .and_return('test_models')
+    end
+
+    it 'the name has the expected value' do
+      expect(model.name).to eq expected
+    end
+  end
+
+  context 'with access to self.table_name', verify_stubs: false do
+    let(:model)    { TestModel.new(slug: 'test') }
+    let(:key)      { :"test_models.test.name" }
+    let(:expected) { 'test-custom-result' }
+
+    before :each do
+      allow(model).to receive(:table_name).and_return('test_models')
     end
 
     it 'the name has the expected value' do

--- a/spec/db_helper.rb
+++ b/spec/db_helper.rb
@@ -1,9 +1,11 @@
-require "codeclimate-test-reporter"
+require 'codeclimate-test-reporter'
 SimpleCov.start do
-  formatter SimpleCov::Formatter::MultiFormatter.new([
-    SimpleCov::Formatter::HTMLFormatter,
-    CodeClimate::TestReporter::Formatter
-  ])
+  formatter SimpleCov::Formatter::MultiFormatter.new(
+    [
+      SimpleCov::Formatter::HTMLFormatter,
+      CodeClimate::TestReporter::Formatter
+    ]
+  )
 end
 
 require 'rspec'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,14 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.around(:each, verify_stubs: false) do |ex|
+    config.mock_with :rspec do |mocks|
+      mocks.verify_partial_doubles = false
+      ex.run
+      mocks.verify_partial_doubles = true
+    end
+  end
+
   # These two settings work together to allow you to limit a spec run
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples


### PR DESCRIPTION
or else tries to pluralize the class name to create the root of the i18n resource key if it can.
